### PR TITLE
fix: uri encoding was creating %2520 instead of %20

### DIFF
--- a/src/services/spotify/search/querySpotifySearch.ts
+++ b/src/services/spotify/search/querySpotifySearch.ts
@@ -16,7 +16,7 @@ export async function querySpotifySearch(
   const url = new URL(`${SPOTIFY_API_URL}/search`);
   url.searchParams.append('type', ['album', 'artist', 'track'].join(','));
   url.searchParams.append('market', 'from_token');
-  url.searchParams.append('q', encodeURIComponent(args.query));
+  url.searchParams.append('q', args.query);
   url.searchParams.append('limit', args.limit.toString()); // 1 - 50
   url.searchParams.append('offset', args.offset.toString()); // 0 - 10,000
 


### PR DESCRIPTION
query string was being encoded to not use space properly. Looks like a double encode issues: https://stackoverflow.com/questions/16084935/a-html-space-is-showing-as-2520-instead-of-20. Took out the uri encoding here so that we can search for songs with spaces now. 