### PR TITLE
Spotify recommendation seed

### DIFF
--- a/src/routes/albumTracks.ts
+++ b/src/routes/albumTracks.ts
@@ -1,0 +1,22 @@
+import { RequestHandler } from 'express-serve-static-core';
+import { getRoomAuthorization } from '../services/database/getRoomAuthorization';
+import { queryAlbum } from '../services/spotify/search/queryAlbums';
+
+export const albumTracks: RequestHandler = async (req, res) => {
+  const { room, albumURI } = req.query;
+
+  try {
+    const auth = await getRoomAuthorization(room);
+
+    const result = await queryAlbum({
+      token: auth.token,
+      tokenType: auth.token_type,
+      albumURI
+    });
+
+    res.status(200).json(result);
+  } catch (err) {
+    console.log(err);
+    res.status(500).send(err.message);
+  }
+};

--- a/src/routes/artistQuery.ts
+++ b/src/routes/artistQuery.ts
@@ -1,0 +1,22 @@
+import { RequestHandler } from 'express-serve-static-core';
+import { getRoomAuthorization } from '../services/database/getRoomAuthorization';
+import { queryArtist } from '../services/spotify/search/queryArtists';
+
+export const artistQuery: RequestHandler = async (req, res) => {
+  const { room, artistURI } = req.query;
+
+  try {
+    const auth = await getRoomAuthorization(room);
+
+    const result = await queryArtist({
+      token: auth.token,
+      tokenType: auth.token_type,
+      artistURI
+    });
+
+    res.status(200).json(result);
+  } catch (err) {
+    console.log(err);
+    res.status(500).send(err.message);
+  }
+};

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -5,11 +5,12 @@ import { spotifyAuthorize } from './spotify/authorize';
 import { spotifyLogin } from './spotify/login';
 
 // App
-import { search } from './search';
 import { addTrack } from './addTrack';
-import { playlistTracks } from './playlistTracks';
 import { albumTracks } from './albumTracks';
 import { artistQuery } from './artistQuery';
+import { playlistTracks } from './playlistTracks';
+import { songRecommendations } from './songRecommendations';
+import { search } from './search';
 
 export default function registerRoutes(app: Express) {
   // Spotify
@@ -25,4 +26,5 @@ export default function registerRoutes(app: Express) {
   app.get('/playlist/tracks', playlistTracks);
   app.get('/album/tracks', albumTracks);
   app.get('/artist/query', artistQuery);
+  app.get('/songRecommendations', songRecommendations);
 }

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -8,6 +8,8 @@ import { spotifyLogin } from './spotify/login';
 import { search } from './search';
 import { addTrack } from './addTrack';
 import { playlistTracks } from './playlistTracks';
+import { albumTracks } from './albumTracks';
+import { artistQuery } from './artistQuery';
 
 export default function registerRoutes(app: Express) {
   // Spotify
@@ -21,4 +23,6 @@ export default function registerRoutes(app: Express) {
   app.get('/search', search);
   app.post('/track', addTrack);
   app.get('/playlist/tracks', playlistTracks);
+  app.get('/album/tracks', albumTracks);
+  app.get('/artist/query', artistQuery);
 }

--- a/src/routes/search.ts
+++ b/src/routes/search.ts
@@ -3,7 +3,7 @@ import { querySpotifySearch } from '../services/spotify';
 import { getRoomAuthorization } from '../services/database/getRoomAuthorization';
 
 export const search: RequestHandler = async (req, res) => {
-  const { room, q, offset, limit } = req.query;
+  const { room, q, offset, limit, searchType } = req.query;
 
   try {
     const auth = await getRoomAuthorization(room);
@@ -13,7 +13,8 @@ export const search: RequestHandler = async (req, res) => {
       offset,
       query: q,
       token: auth.token,
-      tokenType: auth.token_type
+      tokenType: auth.token_type,
+      searchType
     });
 
     res.status(200).json(result);

--- a/src/routes/songRecommendations.ts
+++ b/src/routes/songRecommendations.ts
@@ -1,0 +1,22 @@
+import { RequestHandler } from 'express';
+import { getRoomAuthorization } from '../services/database/getRoomAuthorization';
+import { getSongRecommendations } from '../services/spotify/recommendation/getSongRecommendations';
+
+export const songRecommendations: RequestHandler = async (req, res) => {
+  const { room } = req.query;
+
+  try {
+    const auth = await getRoomAuthorization(room);
+
+    const result = await getSongRecommendations({
+      playlistId: auth.service_playlist_id,
+      token: auth.token,
+      tokenType: auth.token_type
+    });
+
+    res.status(200).json(result);
+  } catch (err) {
+    console.log(err);
+    res.status(500).send(err.message);
+  }
+};

--- a/src/services/spotify/recommendation/getSongRecommendations.ts
+++ b/src/services/spotify/recommendation/getSongRecommendations.ts
@@ -1,0 +1,131 @@
+import { SPOTIFY_API_URL } from '../../../const';
+import { spotifyFetch } from '../fetch';
+import { getSpotifyPlaylistTracks } from '../playlist/getPlaylistTracks';
+
+interface GetSongRecommendationsParameters {
+  playlistId: string;
+  token: string;
+  tokenType: string;
+}
+
+export async function getSongRecommendations(
+  args: GetSongRecommendationsParameters
+) {
+  // GET first 100 songs of playlist
+  const playlistTracks = await getSpotifyPlaylistTracks({
+    token: args.token,
+    tokenType: args.tokenType,
+    playlistId: args.playlistId,
+    offset: 0,
+    limit: 100
+  });
+
+  // Create array of just uris
+  const trackURIs = playlistTracks.items.map((track) => {
+    return track.track.id;
+  });
+
+  // GET audio features for trackURIs
+  const featuresURL = new URL(`${SPOTIFY_API_URL}/audio-features`);
+  featuresURL.searchParams.append('ids', String(trackURIs));
+  const featuresResult = await spotifyFetch(featuresURL.href, {
+    method: 'GET',
+    headers: {
+      Authorization: `${args.tokenType} ${args.token}`,
+      'Content-Type': 'application/json'
+    }
+  });
+  const features = await featuresResult.json();
+
+  // Average the audio features
+  const featuresAverage = features.audio_features.reduce(
+    (sum: any, feature: any) => {
+      return {
+        acousticness: (sum.acousticness + feature.acousticness) / 2,
+        danceability: (sum.danceability + feature.danceability) / 2,
+        energy: (sum.energy + feature.energy) / 2,
+        instrumentalness: (sum.instrumentalness + feature.instrumentalness) / 2,
+        liveness: (sum.liveness + feature.liveness) / 2,
+        loudness: (sum.loudness + feature.loudness) / 2,
+        speechiness: (sum.speechiness + feature.speechiness) / 2,
+        tempo: (sum.tempo + feature.tempo) / 2,
+        valence: (sum.valence + feature.valence) / 2
+      };
+    },
+    {
+      acousticness: features.audio_features[0].acousticness,
+      danceability: features.audio_features[0].danceability,
+      energy: features.audio_features[0].energy,
+      instrumentalness: features.audio_features[0].instrumentalness,
+      liveness: features.audio_features[0].liveness,
+      loudness: features.audio_features[0].loudness,
+      speechiness: features.audio_features[0].speechiness,
+      tempo: features.audio_features[0].tempo,
+      valence: features.audio_features[0].valence
+    }
+  );
+
+  /**
+   * Pick 5 random tracks to seed the recommendation.
+   * This should also allow each person viewing to get a different seed of recommendations,
+   * allowing for everyone to see different recommendations each time. Should allow for more
+   * recommendations overall (in theory).
+   */
+  const seedTrackUris = [
+    trackURIs[Math.floor(Math.random() * trackURIs.length)],
+    trackURIs[Math.floor(Math.random() * trackURIs.length)],
+    trackURIs[Math.floor(Math.random() * trackURIs.length)],
+    trackURIs[Math.floor(Math.random() * trackURIs.length)],
+    trackURIs[Math.floor(Math.random() * trackURIs.length)]
+  ];
+
+  // GET 20 song recommendations based on seed tracks, and average audio features
+  const recomendationsURL = new URL(`${SPOTIFY_API_URL}/recommendations`);
+  recomendationsURL.searchParams.append('seed_tracks', String(seedTrackUris));
+  recomendationsURL.searchParams.append(
+    'target_acousticness',
+    String(featuresAverage.acousticness)
+  );
+  recomendationsURL.searchParams.append(
+    'target_danceability',
+    String(featuresAverage.danceability)
+  );
+  recomendationsURL.searchParams.append(
+    'target_energy',
+    String(featuresAverage.energy)
+  );
+  recomendationsURL.searchParams.append(
+    'target_instrumentalness',
+    String(featuresAverage.instrumentalness)
+  );
+  recomendationsURL.searchParams.append(
+    'target_liveness',
+    String(featuresAverage.liveness)
+  );
+  recomendationsURL.searchParams.append(
+    'target_loudness',
+    String(featuresAverage.loudness)
+  );
+  recomendationsURL.searchParams.append(
+    'target_speechiness',
+    String(featuresAverage.speechiness)
+  );
+  recomendationsURL.searchParams.append(
+    'target_tempo',
+    String(featuresAverage.tempo)
+  );
+  recomendationsURL.searchParams.append(
+    'target_valence',
+    String(featuresAverage.valence)
+  );
+  const recommendationsResult = await spotifyFetch(recomendationsURL.href, {
+    method: 'GET',
+    headers: {
+      Authorization: `${args.tokenType} ${args.token}`,
+      'Content-Type': 'application/json'
+    }
+  });
+  const recommendations = await recommendationsResult.json();
+
+  return recommendations.tracks;
+}

--- a/src/services/spotify/search/queryAlbums.ts
+++ b/src/services/spotify/search/queryAlbums.ts
@@ -1,0 +1,29 @@
+import { SPOTIFY_API_URL } from '../../../const';
+import { spotifyFetch } from '../fetch';
+import { SpotifyTokenType } from '../types';
+
+// Interface
+interface QuerySpotifyAlbumParameters {
+  token: string;
+  tokenType: SpotifyTokenType;
+  albumURI: string;
+}
+
+export async function queryAlbum(args: QuerySpotifyAlbumParameters) {
+  const url = new URL(`${SPOTIFY_API_URL}/albums/${args.albumURI}`);
+
+  const result = await spotifyFetch(url.href, {
+    method: 'GET',
+    headers: {
+      Authorization: `${args.tokenType} ${args.token}`
+    }
+  });
+
+  const json = await result.json();
+
+  if (!result.ok) {
+    throw json;
+  }
+
+  return json;
+}

--- a/src/services/spotify/search/queryArtists.ts
+++ b/src/services/spotify/search/queryArtists.ts
@@ -1,0 +1,60 @@
+import { SPOTIFY_API_URL } from '../../../const';
+import { spotifyFetch } from '../fetch';
+import { SpotifyTokenType } from '../types';
+
+// Interface
+interface QuerySpotifyArtistParameters {
+  token: string;
+  tokenType: SpotifyTokenType;
+  artistURI: string;
+}
+
+export async function queryArtist(args: QuerySpotifyArtistParameters) {
+  const meURL = new URL(`${SPOTIFY_API_URL}/me`);
+  const meResult = await spotifyFetch(meURL.href, {
+    method: 'GET',
+    headers: {
+      Authorization: `${args.tokenType} ${args.token}`
+    }
+  });
+  const meJSON = await meResult.json();
+
+  const topTenURL = new URL(
+    `${SPOTIFY_API_URL}/artists/${args.artistURI}/top-tracks`
+  );
+  topTenURL.searchParams.append('country', meJSON.country);
+  const topTenResult = await spotifyFetch(topTenURL.href, {
+    method: 'GET',
+    headers: {
+      Authorization: `${args.tokenType} ${args.token}`
+    }
+  });
+  const topTenJSON = await topTenResult.json();
+
+  const albumURL = new URL(
+    `${SPOTIFY_API_URL}/artists/${args.artistURI}/albums`
+  );
+  albumURL.searchParams.append('market', meJSON.country);
+  const albumResult = await spotifyFetch(albumURL.href, {
+    method: 'GET',
+    headers: {
+      Authorization: `${args.tokenType} ${args.token}`
+    }
+  });
+  const albumJSON = await albumResult.json();
+
+  // Remove duplicate albums that have different URI's, regional data, etc...
+  const albums = albumJSON.items.filter(
+    (albumJSON: any, index: any, self: any) =>
+      index ===
+      self.findIndex(
+        (album: any) =>
+          album.place === albumJSON.place && album.name === albumJSON.name
+      )
+  );
+
+  return {
+    ...topTenJSON,
+    albums
+  };
+}

--- a/src/services/spotify/search/querySpotifySearch.ts
+++ b/src/services/spotify/search/querySpotifySearch.ts
@@ -8,13 +8,14 @@ interface QuerySpotifySearchParameters {
   query: string;
   limit: number;
   offset: number;
+  searchType: string;
 }
 
 export async function querySpotifySearch(
   args: QuerySpotifySearchParameters
 ): Promise<SpotifySearchResult> {
   const url = new URL(`${SPOTIFY_API_URL}/search`);
-  url.searchParams.append('type', ['album', 'artist', 'track'].join(','));
+  url.searchParams.append('type', args.searchType);
   url.searchParams.append('market', 'from_token');
   url.searchParams.append('q', args.query);
   url.searchParams.append('limit', args.limit.toString()); // 1 - 50


### PR DESCRIPTION
This PR includes the code in https://github.com/CSSmitty/Spoofity_Server/pull/6. 

Created an endpoint to get song recommendations for Spotify playlists. This endpoint will take as a query parameter the roomcode. From there it gets the first 100 songs for the user, the song features for these songs, and then creates a seed for the recommendations. It will return 20 song recommendations.